### PR TITLE
Add properties in ManagedLedgerInfo to support AMQP metadata persistence.

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/AsyncCallbacks.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/AsyncCallbacks.java
@@ -20,6 +20,7 @@ package org.apache.bookkeeper.mledger;
 
 import com.google.common.annotations.Beta;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 /**
@@ -136,5 +137,11 @@ public interface AsyncCallbacks {
         void offloadComplete(Position pos, Object ctx);
 
         void offloadFailed(ManagedLedgerException exception, Object ctx);
+    }
+
+    interface SetPropertiesCallback {
+        void setPropertiesComplete(Map<String, String> properties, Object ctx);
+
+        void setPropertiesFailed(ManagedLedgerException exception, Object ctx);
     }
 }

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedger.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedger.java
@@ -447,4 +447,18 @@ public interface ManagedLedger {
      * Signaling managed ledger that we can resume after BK write failure
      */
     void readyToCreateNewLedger();
+
+    /**
+     * Returns managed-ledger's properties.
+     *
+     * @return key-values of properties
+     */
+    Map<String, String> getProperties();
+
+    /**
+     * Updates managed-ledger's properties.
+     *
+     * @param properties key-values of properties
+     */
+    void setProperties(Map<String, String> properties) throws InterruptedException;
 }

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedger.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedger.java
@@ -456,9 +456,19 @@ public interface ManagedLedger {
     Map<String, String> getProperties();
 
     /**
-     * Updates managed-ledger's properties.
+     * Update managed-ledger's properties.
      *
      * @param properties key-values of properties
      */
     void setProperties(Map<String, String> properties) throws InterruptedException;
+
+    /**
+     * Async update managed-ledger's properties.
+     *
+     * @param properties key-values of properties.
+     * @param callback   a callback which will be supplied with the newest properties in managedLedger.
+     * @param ctx        a context object which will be passed to the callback on completion.
+     */
+    void asyncSetProperties(Map<String, String> properties, final AsyncCallbacks.SetPropertiesCallback callback,
+        Object ctx);
 }

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedgerInfo.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedgerInfo.java
@@ -33,6 +33,8 @@ public class ManagedLedgerInfo {
 
     public Map<String, CursorInfo> cursors;
 
+    public Map<String, String> properties;
+
     public static class LedgerInfo {
         public long ledgerId;
         public Long entries;

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerFactoryImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerFactoryImpl.java
@@ -519,6 +519,14 @@ public class ManagedLedgerFactoryImpl implements ManagedLedgerFactory {
                     info.terminatedPosition.entryId = pbInfo.getTerminatedPosition().getEntryId();
                 }
 
+                if (pbInfo.getPropertiesCount() > 0) {
+                    info.properties = Maps.newTreeMap();
+                    for (int i = 0; i < pbInfo.getPropertiesCount(); i++) {
+                        MLDataFormats.KeyValue property = pbInfo.getProperties(i);
+                        info.properties.put(property.getKey(), property.getValue());
+                    }
+                }
+
                 for (int i = 0; i < pbInfo.getLedgerInfoCount(); i++) {
                     MLDataFormats.ManagedLedgerInfo.LedgerInfo pbLedgerInfo = pbInfo.getLedgerInfo(i);
                     LedgerInfo ledgerInfo = new LedgerInfo();

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -109,6 +109,7 @@ import org.apache.bookkeeper.mledger.Position;
 import org.apache.bookkeeper.mledger.impl.ManagedCursorImpl.VoidCallback;
 import org.apache.bookkeeper.mledger.impl.MetaStore.MetaStoreCallback;
 import org.apache.bookkeeper.mledger.offload.OffloadUtils;
+import org.apache.bookkeeper.mledger.proto.MLDataFormats;
 import org.apache.bookkeeper.mledger.proto.MLDataFormats.ManagedLedgerInfo;
 import org.apache.bookkeeper.mledger.proto.MLDataFormats.ManagedLedgerInfo.LedgerInfo;
 import org.apache.bookkeeper.mledger.proto.MLDataFormats.NestedPositionInfo;
@@ -133,6 +134,7 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
     private final BookKeeper.DigestType digestType;
 
     protected ManagedLedgerConfig config;
+    protected Map<String, String> propertiesMap;
     protected final MetaStore store;
 
     private final ConcurrentLongHashMap<CompletableFuture<ReadHandle>> ledgerCache = new ConcurrentLongHashMap<>(
@@ -283,6 +285,7 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
         // Get the next rollover time. Add a random value upto 5% to avoid rollover multiple ledgers at the same time
         this.maximumRolloverTimeMs = (long) (config.getMaximumRolloverTimeMs() * (1 + random.nextDouble() * 5 / 100.0));
         this.mlOwnershipChecker = mlOwnershipChecker;
+        this.propertiesMap = Maps.newHashMap();
     }
 
     synchronized void initialize(final ManagedLedgerInitializeLedgerCallback callback, final Object ctx) {
@@ -3181,6 +3184,51 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
         }
 
         return offloadedSize;
+    }
+
+    @Override
+    public Map<String, String> getProperties() {
+        return propertiesMap;
+    }
+
+    @Override
+    public void setProperties(Map<String, String> properties) throws InterruptedException {
+        final CountDownLatch latch = new CountDownLatch(2);
+        store.getManagedLedgerInfo(name, false, new MetaStoreCallback<ManagedLedgerInfo>() {
+            @Override
+            public void operationComplete(ManagedLedgerInfo result, Stat version) {
+                ledgersStat = version;
+                // Update manageLedger's  properties.
+                ManagedLedgerInfo.Builder info = ManagedLedgerInfo.newBuilder(result);
+                info.clearProperties();
+                for (Map.Entry<String, String> property : properties.entrySet()) {
+                    info.addProperties(MLDataFormats.KeyValue.newBuilder().setKey(property.getKey()).setValue(property.getValue()));
+                }
+                store.asyncUpdateLedgerIds(name, info.build(), version, new MetaStoreCallback<Void>() {
+                    @Override
+                    public void operationComplete(Void result, Stat version) {
+                        ledgersStat = version;
+                        propertiesMap.clear();
+                        propertiesMap.putAll(properties);
+                        latch.countDown();
+                    }
+
+                    @Override
+                    public void operationFailed(MetaStoreException e) {
+                        log.error("[{}] Update manageLedger's info failed:{}", name, e.getMessage());
+                        latch.countDown();
+                    }
+                });
+                latch.countDown();
+            }
+
+            @Override
+            public void operationFailed(MetaStoreException e) {
+                log.error("[{}] Get manageLedger's info failed:{}", name, e.getMessage());
+                latch.countDown();
+            }
+        });
+        latch.await();
     }
 
     @VisibleForTesting

--- a/managed-ledger/src/main/proto/MLDataFormats.proto
+++ b/managed-ledger/src/main/proto/MLDataFormats.proto
@@ -56,6 +56,8 @@ message ManagedLedgerInfo {
     // committed entry.
     // No more entries can be written.
     optional NestedPositionInfo terminatedPosition = 2;
+
+    repeated KeyValue properties = 3;
 }
 
 message PositionInfo {

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
@@ -47,6 +47,7 @@ import java.nio.charset.Charset;
 import java.security.GeneralSecurityException;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -1167,6 +1168,24 @@ public class ManagedLedgerTest extends MockedBookKeeperTestCase {
         c2.close();
         ledger.deleteCursor("c2");
         assertEquals(Sets.newHashSet(ledger.getCursors()), Sets.newHashSet());
+    }
+
+    @Test
+    public void testSetProperties() throws Exception {
+        ManagedLedger ledger = factory.open("my_test_ledger");
+        Map<String, String> properties = new HashMap<>();
+        properties.put("key1", "value1");
+        properties.put("key2", "value2");
+        properties.put("key3", "value3");
+        ledger.setProperties(properties);
+        assertEquals(ledger.getProperties(), properties);
+
+        Map<String, String> newProperties = new HashMap<>();
+        newProperties.put("key4", "value4");
+        newProperties.put("key5", "value5");
+        newProperties.put("key6", "value6");
+        ledger.setProperties(newProperties);
+        assertEquals(ledger.getProperties(), newProperties);
     }
 
     @Test

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
@@ -76,6 +76,7 @@ import org.apache.bookkeeper.client.PulsarMockLedgerHandle;
 import org.apache.bookkeeper.client.api.LedgerEntries;
 import org.apache.bookkeeper.client.api.ReadHandle;
 import org.apache.bookkeeper.conf.ClientConfiguration;
+import org.apache.bookkeeper.mledger.AsyncCallbacks;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.AddEntryCallback;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.CloseCallback;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.DeleteLedgerCallback;
@@ -1186,6 +1187,39 @@ public class ManagedLedgerTest extends MockedBookKeeperTestCase {
         newProperties.put("key6", "value6");
         ledger.setProperties(newProperties);
         assertEquals(ledger.getProperties(), newProperties);
+    }
+
+    @Test
+    public void testAsyncSetProperties() throws Exception {
+        ManagedLedger ledger = factory.open("my_test_ledger");
+        Map<String, String> properties = new HashMap<>();
+        properties.put("key1", "value1");
+        properties.put("key2", "value2");
+        properties.put("key3", "value3");
+        ledger.asyncSetProperties(properties, new AsyncCallbacks.SetPropertiesCallback() {
+            @Override
+            public void setPropertiesComplete(Map<String, String> properties, Object ctx) {
+                assertEquals(ledger.getProperties(), properties);
+                Map<String, String> newProperties = new HashMap<>();
+                newProperties.put("key4", "value4");
+                newProperties.put("key5", "value5");
+                newProperties.put("key6", "value6");
+                ledger.asyncSetProperties(properties, new AsyncCallbacks.SetPropertiesCallback() {
+                    @Override
+                    public void setPropertiesComplete(Map<String, String> properties, Object ctx) {
+                        assertEquals(ledger.getProperties(), newProperties);
+                    }
+                    @Override
+                    public void setPropertiesFailed(ManagedLedgerException exception, Object ctx) {
+                        fail("should have succeeded");
+                    }
+                }, null);
+            }
+            @Override
+            public void setPropertiesFailed(ManagedLedgerException exception, Object ctx) {
+                fail("should have succeeded");
+            }
+        }, null);
     }
 
     @Test

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
@@ -1191,35 +1191,30 @@ public class ManagedLedgerTest extends MockedBookKeeperTestCase {
 
     @Test
     public void testAsyncSetProperties() throws Exception {
+        final CountDownLatch latch = new CountDownLatch(1);
         ManagedLedger ledger = factory.open("my_test_ledger");
         Map<String, String> properties = new HashMap<>();
         properties.put("key1", "value1");
         properties.put("key2", "value2");
         properties.put("key3", "value3");
-        ledger.asyncSetProperties(properties, new AsyncCallbacks.SetPropertiesCallback() {
+        ledger.setProperties(properties);
+        Map<String, String> newProperties = new HashMap<>();
+        newProperties.put("key4", "value4");
+        newProperties.put("key5", "value5");
+        newProperties.put("key6", "value6");
+        ledger.asyncSetProperties(newProperties, new AsyncCallbacks.SetPropertiesCallback() {
             @Override
             public void setPropertiesComplete(Map<String, String> properties, Object ctx) {
-                assertEquals(ledger.getProperties(), properties);
-                Map<String, String> newProperties = new HashMap<>();
-                newProperties.put("key4", "value4");
-                newProperties.put("key5", "value5");
-                newProperties.put("key6", "value6");
-                ledger.asyncSetProperties(properties, new AsyncCallbacks.SetPropertiesCallback() {
-                    @Override
-                    public void setPropertiesComplete(Map<String, String> properties, Object ctx) {
-                        assertEquals(ledger.getProperties(), newProperties);
-                    }
-                    @Override
-                    public void setPropertiesFailed(ManagedLedgerException exception, Object ctx) {
-                        fail("should have succeeded");
-                    }
-                }, null);
+                latch.countDown();
             }
+
             @Override
             public void setPropertiesFailed(ManagedLedgerException exception, Object ctx) {
                 fail("should have succeeded");
             }
         }, null);
+        latch.await();
+        assertEquals(ledger.getProperties(), newProperties);
     }
 
     @Test


### PR DESCRIPTION
**Motivation**
Add properties in ManagedLedgerInfo to support AMQP metadata persistence.

**Modifications**
1. Add propertiesMap in ManagedLedgerImpl to record the properties.
2. Add get and set method for the new added property.

**Verifying this change**
new unit test added.

Does this pull request potentially affect one of the following parts:
If yes was chosen, please highlight the changes

Dependencies (does it add or upgrade a dependency): (no)
The public API: (no)
The schema: (no)
The default values of configurations: (no)
The wire protocol: (no)
The rest endpoints: ( no)
The admin cli options: (no)
Anything that affects deployment: (no)
Documentation
Does this pull request introduce a new feature? (no)