### PR TITLE
Turn the topic count mismatch to warn

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
@@ -878,9 +878,10 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
                 }
                 int numTopics = this.topics.values().stream().mapToInt(Integer::intValue).sum();
                 int currentAllTopicsPartitionsNumber = allTopicPartitionsNumber.get();
-                checkState(currentAllTopicsPartitionsNumber == numTopics,
-                    "allTopicPartitionsNumber " + currentAllTopicsPartitionsNumber
-                        + " not equals expected: " + numTopics);
+                if (currentAllTopicsPartitionsNumber != numTopics) {
+                    log.warn("Topic count mismatch: allTopicPartitionsNumber " + currentAllTopicsPartitionsNumber
+                            + " not equals expected: " + numTopics);
+                }
 
                 // We have successfully created new consumers, so we can start receiving messages for them
                 startReceivingMessages(


### PR DESCRIPTION
Currently, an underlying race condition results in occasionally an
assertion breaking.

This assertion happens "too early" because some futures may not yet have
updated in the map, this should be fixed, but for now, we turn that
assertion into a warning instead of throwing an exception
