### PR TITLE
[Issue ???][broker] Multiple Bind Addresses and Smart Listeners

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -168,6 +168,14 @@ public class ServiceConfiguration implements PulsarConfiguration {
     private String internalListenerName;
 
     @FieldContext(category=CATEGORY_SERVER,
+            doc = "Used to specify multiple bind addresses for the broker."
+                    + " The value must format as <listener_name>:pulsar://<host>:<port>,"
+                    + "multiple bind addresses should separate with commas."
+                    + "Use this configuration with advertisedListeners."
+                    + "The Default value is absent means use bindAddress for all listeners.")
+    private String bindAddresses;
+
+    @FieldContext(category=CATEGORY_SERVER,
             doc = "Enable or disable the proxy protocol.")
     private boolean haProxyProtocolEnabled;
 

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfigurationUtils.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfigurationUtils.java
@@ -80,4 +80,11 @@ public class ServiceConfigurationUtils {
         return getDefaultOrConfiguredAddress(advertisedAddress);
     }
 
+    public static String brokerUrl(String host, int port) {
+        return String.format("pulsar://%s:%d", host, port);
+    }
+
+    public static String brokerUrlTls(String host, int port) {
+        return String.format("pulsar+ssl://%s:%d", host, port);
+    }
 }

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/validator/BindAddressValidator.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/validator/BindAddressValidator.java
@@ -1,0 +1,83 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.validator;
+
+import java.net.URI;
+import java.util.Arrays;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.ArrayList;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.pulsar.broker.ServiceConfiguration;
+import org.apache.pulsar.broker.ServiceConfigurationUtils;
+import org.apache.pulsar.common.configuration.BindAddress;
+
+import static java.util.stream.Collectors.toList;
+
+/**
+ * Validates bind address configurations.
+ */
+public class BindAddressValidator {
+
+    private static final Pattern bindAddress = Pattern.compile("(?<name>\\w+):(?<url>.+)$");
+
+    /**
+     * Validate the configuration of `bindAddresses`.
+     * @param config the pulsar broker configure.
+     * @return a list of bind addresses.
+     */
+    public static List<BindAddress> validateBindAddresses(ServiceConfiguration config) {
+        // migrate the existing configuration properties
+        List<BindAddress> addresses = migrateBindAddresses(config);
+        if (StringUtils.isBlank(config.getBindAddresses())) {
+            return addresses;
+        }
+
+        // parse the list of additional bind addresses
+        Arrays
+                .stream(StringUtils.split(config.getBindAddresses(), ","))
+                .map(bindAddress::matcher)
+                .filter(Matcher::matches)
+                .map(m -> new BindAddress(m.group("name"), URI.create(m.group("url"))))
+                .filter(m -> StringUtils.equalsAnyIgnoreCase(m.getAddress().getScheme(), "pulsar", "pulsar+ssl"))
+                .forEach(addresses::add);
+
+        return addresses;
+    }
+
+    /**
+     * Generates bind addresses based on legacy configuration.
+     * When no bind addresses are defined:
+     * - generate a bind address for the internal listener
+     *   on bindAddress:brokerServicePort and/or bindAddress:brokerServicePortTls.
+     */
+    private static List<BindAddress> migrateBindAddresses(ServiceConfiguration config) {
+        List<BindAddress> addresses = new ArrayList<>(2);
+        if (config.getBrokerServicePort().isPresent()) {
+            addresses.add(new BindAddress(null, URI.create(
+                    ServiceConfigurationUtils.brokerUrl(config.getBindAddress(), config.getBrokerServicePort().get()))));
+        }
+        if (config.getBrokerServicePortTls().isPresent()) {
+            addresses.add(new BindAddress(null, URI.create(
+                    ServiceConfigurationUtils.brokerUrlTls(config.getBindAddress(), config.getBrokerServicePortTls().get()))));
+        }
+        return addresses;
+    }
+}

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/validator/MultipleListenerValidator.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/validator/MultipleListenerValidator.java
@@ -33,7 +33,7 @@ import java.util.Optional;
 import java.util.Set;
 
 /**
- * the validator for pulsar multiple  listeners.
+ * Validates multiple listener address configurations.
  */
 public final class MultipleListenerValidator {
 
@@ -109,21 +109,6 @@ public final class MultipleListenerValidator {
                 } catch (Throwable cause) {
                     throw new IllegalArgumentException("the value " + strUri + " in the `advertisedListeners` configure is invalid");
                 }
-            }
-            if (!config.getBrokerServicePortTls().isPresent()) {
-                if (pulsarSslAddress != null) {
-                    throw new IllegalArgumentException("If pulsar do not start ssl port, there is no need to configure " +
-                            " `pulsar+ssl` in `" + entry.getKey() + "` listener.");
-                }
-            } else {
-                if (pulsarSslAddress == null) {
-                    throw new IllegalArgumentException("the `" + entry.getKey() + "` listener in the `advertisedListeners` "
-                            + " do not specify `pulsar+ssl` address.");
-                }
-            }
-            if (pulsarAddress == null) {
-                throw new IllegalArgumentException("the `" + entry.getKey() + "` listener in the `advertisedListeners` "
-                        + " do not specify `pulsar` address.");
             }
             result.put(entry.getKey(), AdvertisedListener.builder().brokerServiceUrl(pulsarAddress).brokerServiceUrlTls(pulsarSslAddress).build());
         }

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/common/configuration/BindAddress.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/common/configuration/BindAddress.java
@@ -1,0 +1,69 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.common.configuration;
+
+import java.net.URI;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+import lombok.Setter;
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * A bind address for the broker as a non-TLS and TLS pair.
+ */
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode
+public class BindAddress {
+
+    @Getter
+    @Setter
+    // the listener name associated with the bind address, or null if no listener is associated.
+    private String listenerName;
+
+    @Getter
+    @Setter
+    @NonNull
+    // the broker bind address
+    private URI address;
+
+    /**
+     * A convenience method indicating whether the bind address should have TLS.
+     */
+    public boolean isTLS() {
+        return StringUtils.equalsIgnoreCase(this.address.getScheme(), "pulsar+ssl");
+    }
+
+//    @Getter
+//    @Setter
+//    @Deprecated
+//    // the broker bind address without ssl
+//    private InetSocketAddress brokerBindAddress;
+//
+//    @Getter
+//    @Setter
+//    @Deprecated
+//    // the broker bind address with ssl
+//    private InetSocketAddress brokerBindAddressTls;
+}

--- a/pulsar-broker-common/src/test/java/org/apache/pulsar/broker/validator/BindAddressValidatorTest.java
+++ b/pulsar-broker-common/src/test/java/org/apache/pulsar/broker/validator/BindAddressValidatorTest.java
@@ -1,0 +1,121 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.validator;
+
+import java.net.URI;
+import java.util.List;
+import java.util.Optional;
+import org.apache.pulsar.broker.ServiceConfiguration;
+import org.apache.pulsar.common.configuration.BindAddress;
+import org.testng.annotations.Test;
+
+import static org.testng.AssertJUnit.assertEquals;
+
+/**
+ * testcase for BindAddressValidator.
+ */
+public class BindAddressValidatorTest {
+
+    @Test
+    public void testInvalidScheme() {
+        ServiceConfiguration config = new ServiceConfiguration();
+        config.setBrokerServicePort(Optional.empty());
+        config.setBindAddresses("internal:pulsar://0.0.0.0:6650,internal:invalid://0.0.0.0:6651");
+        List<BindAddress> addresses = BindAddressValidator.validateBindAddresses(config);
+        assertEquals(1, addresses.size());
+        assertEquals(new BindAddress("internal", URI.create("pulsar://0.0.0.0:6650")), addresses.get(0));
+    }
+
+    @Test
+    public void testMalformed() {
+        ServiceConfiguration config = new ServiceConfiguration();
+        config.setBrokerServicePort(Optional.empty());
+        config.setBindAddresses("internal:");
+        List<BindAddress> addresses = BindAddressValidator.validateBindAddresses(config);
+        assertEquals(0, addresses.size());
+    }
+
+    @Test
+    public void testOneListenerMultipleAddresses() {
+        ServiceConfiguration config = new ServiceConfiguration();
+        config.setBrokerServicePort(Optional.empty());
+        config.setBrokerServicePortTls(Optional.empty());
+        config.setBindAddresses("internal:pulsar://0.0.0.0:6650,internal:pulsar+ssl://0.0.0.0:6651");
+        List<BindAddress> addresses = BindAddressValidator.validateBindAddresses(config);
+        assertEquals(2, addresses.size());
+        assertEquals(new BindAddress("internal", URI.create("pulsar://0.0.0.0:6650")), addresses.get(0));
+        assertEquals(new BindAddress("internal", URI.create("pulsar+ssl://0.0.0.0:6651")), addresses.get(1));
+    }
+
+    @Test
+    public void testMultiListener() {
+        ServiceConfiguration config = new ServiceConfiguration();
+        config.setBrokerServicePort(Optional.empty());
+        config.setBrokerServicePortTls(Optional.empty());
+        config.setBindAddresses("internal:pulsar://0.0.0.0:6650,external:pulsar+ssl://0.0.0.0:6651");
+        List<BindAddress> addresses = BindAddressValidator.validateBindAddresses(config);
+        assertEquals(2, addresses.size());
+        assertEquals(new BindAddress("internal", URI.create("pulsar://0.0.0.0:6650")), addresses.get(0));
+        assertEquals(new BindAddress("external", URI.create("pulsar+ssl://0.0.0.0:6651")), addresses.get(1));
+    }
+
+    @Test
+    public void testMigrationNonTls() {
+        ServiceConfiguration config = new ServiceConfiguration();
+        config.setBrokerServicePort(Optional.of(6650));
+        config.setBrokerServicePortTls(Optional.empty());
+        List<BindAddress> addresses = BindAddressValidator.validateBindAddresses(config);
+        assertEquals(1, addresses.size());
+        assertEquals(new BindAddress(null, URI.create("pulsar://0.0.0.0:6650")), addresses.get(0));
+    }
+
+    @Test
+    public void testMigrationNonTlsWithExtra() {
+        ServiceConfiguration config = new ServiceConfiguration();
+        config.setBrokerServicePort(Optional.of(6650));
+        config.setBrokerServicePortTls(Optional.empty());
+        config.setBindAddresses("extra:pulsar://0.0.0.0:6652");
+        List<BindAddress> addresses = BindAddressValidator.validateBindAddresses(config);
+        assertEquals(2, addresses.size());
+        assertEquals(new BindAddress(null, URI.create("pulsar://0.0.0.0:6650")), addresses.get(0));
+        assertEquals(new BindAddress("extra", URI.create("pulsar://0.0.0.0:6652")), addresses.get(1));
+    }
+
+    @Test
+    public void testMigrationTls() {
+        ServiceConfiguration config = new ServiceConfiguration();
+        config.setBrokerServicePort(Optional.empty());
+        config.setBrokerServicePortTls(Optional.of(6651));
+        List<BindAddress> addresses = BindAddressValidator.validateBindAddresses(config);
+        assertEquals(1, addresses.size());
+        assertEquals(new BindAddress(null, URI.create("pulsar+ssl://0.0.0.0:6651")), addresses.get(0));
+    }
+
+    @Test
+    public void testMigrationTlsWithExtra() {
+        ServiceConfiguration config = new ServiceConfiguration();
+        config.setBrokerServicePort(Optional.empty());
+        config.setBrokerServicePortTls(Optional.of(6651));
+        config.setBindAddresses("extra:pulsar://0.0.0.0:6652");
+        List<BindAddress> addresses = BindAddressValidator.validateBindAddresses(config);
+        assertEquals(2, addresses.size());
+        assertEquals(new BindAddress(null, URI.create("pulsar+ssl://0.0.0.0:6651")), addresses.get(0));
+        assertEquals(new BindAddress("extra", URI.create("pulsar://0.0.0.0:6652")), addresses.get(1));
+    }
+}

--- a/pulsar-broker-common/src/test/java/org/apache/pulsar/broker/validator/MultipleListenerValidatorTest.java
+++ b/pulsar-broker-common/src/test/java/org/apache/pulsar/broker/validator/MultipleListenerValidatorTest.java
@@ -93,28 +93,11 @@ public class MultipleListenerValidatorTest {
         MultipleListenerValidator.validateAndAnalysisAdvertisedListener(config);
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
-    public void testListenerWithoutTLSPort() {
-        ServiceConfiguration config = new ServiceConfiguration();
-        config.setAdvertisedListeners(" internal:pulsar://127.0.0.1:6660, internal:pulsar+ssl://127.0.0.1:6651");
-        config.setInternalListenerName("internal");
-        MultipleListenerValidator.validateAndAnalysisAdvertisedListener(config);
-    }
-
     @Test
     public void testListenerWithTLSPort() {
         ServiceConfiguration config = new ServiceConfiguration();
         config.setBrokerServicePortTls(Optional.of(6651));
         config.setAdvertisedListeners(" internal:pulsar://127.0.0.1:6660, internal:pulsar+ssl://127.0.0.1:6651");
-        config.setInternalListenerName("internal");
-        MultipleListenerValidator.validateAndAnalysisAdvertisedListener(config);
-    }
-
-    @Test(expectedExceptions = IllegalArgumentException.class)
-    public void testListenerWithoutNonTLSAddress() {
-        ServiceConfiguration config = new ServiceConfiguration();
-        config.setBrokerServicePortTls(Optional.of(6651));
-        config.setAdvertisedListeners(" internal:pulsar+ssl://127.0.0.1:6651");
         config.setInternalListenerName("internal");
         MultipleListenerValidator.validateAndAnalysisAdvertisedListener(config);
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -1444,7 +1444,7 @@ public class PulsarService implements AutoCloseable {
     }
 
     public static String brokerUrl(String host, int port) {
-        return String.format("pulsar://%s:%d", host, port);
+        return ServiceConfigurationUtils.brokerUrl(host, port);
     }
 
     public String brokerUrlTls(ServiceConfiguration config) {
@@ -1457,7 +1457,7 @@ public class PulsarService implements AutoCloseable {
     }
 
     public static String brokerUrlTls(String host, int port) {
-        return String.format("pulsar+ssl://%s:%d", host, port);
+        return ServiceConfigurationUtils.brokerUrlTls(host, port);
     }
 
     public String webAddress(ServiceConfiguration config) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/lookup/v2/TopicLookup.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/lookup/v2/TopicLookup.java
@@ -23,6 +23,7 @@ import io.swagger.annotations.ApiResponses;
 import javax.ws.rs.DefaultValue;
 import javax.ws.rs.Encoded;
 import javax.ws.rs.GET;
+import javax.ws.rs.HeaderParam;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
@@ -30,11 +31,14 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.container.AsyncResponse;
 import javax.ws.rs.container.Suspended;
 import javax.ws.rs.core.MediaType;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.broker.lookup.TopicLookupBase;
 import org.apache.pulsar.common.naming.TopicName;
 
 @Path("/v2/topic")
 public class TopicLookup extends TopicLookupBase {
+
+    static final String LISTENERNAME_HEADER = "X-Pulsar-ListenerName";
 
     @GET
     @Path("{topic-domain}/{tenant}/{namespace}/{topic}")
@@ -45,8 +49,12 @@ public class TopicLookup extends TopicLookupBase {
             @PathParam("namespace") String namespace, @PathParam("topic") @Encoded String encodedTopic,
             @QueryParam("authoritative") @DefaultValue("false") boolean authoritative,
             @Suspended AsyncResponse asyncResponse,
-            @QueryParam("listenerName") String listenerName) {
+            @QueryParam("listenerName") String listenerName,
+            @HeaderParam(LISTENERNAME_HEADER) String listenerNameHeader) {
         TopicName topicName = getTopicName(topicDomain, tenant, namespace, encodedTopic);
+        if (StringUtils.isEmpty(listenerName)) {
+            listenerName = listenerNameHeader;
+        }
         internalLookupTopicAsync(topicName, authoritative, asyncResponse, listenerName);
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
@@ -421,9 +421,10 @@ public class NamespaceService implements AutoCloseable {
                                     new PulsarServerException("the broker do not have "
                                             + options.getAdvertisedListenerName() + " listener"));
                         } else {
+                            URI url = listener.getBrokerServiceUrl();
                             URI urlTls = listener.getBrokerServiceUrlTls();
                             future.complete(Optional.of(new LookupResult(nsData.get(),
-                                    listener.getBrokerServiceUrl().toString(),
+                                    url == null ? null : url.toString(),
                                     urlTls == null ? null : urlTls.toString())));
                         }
                         return;
@@ -542,9 +543,11 @@ public class NamespaceService implements AutoCloseable {
                                                 + options.getAdvertisedListenerName() + " listener"));
                                 return;
                             } else {
+                                URI url = listener.getBrokerServiceUrl();
                                 URI urlTls = listener.getBrokerServiceUrlTls();
                                 lookupFuture.complete(Optional.of(
-                                        new LookupResult(ownerInfo, listener.getBrokerServiceUrl().toString(),
+                                        new LookupResult(ownerInfo,
+                                                url == null ? null : url.toString(),
                                                 urlTls == null ? null : urlTls.toString())));
                                 return;
                             }
@@ -603,9 +606,10 @@ public class NamespaceService implements AutoCloseable {
                                     new PulsarServerException(
                                             "the broker do not have " + advertisedListenerName + " listener"));
                         } else {
+                            URI url = listener.getBrokerServiceUrl();
                             URI urlTls = listener.getBrokerServiceUrlTls();
                             lookupFuture.complete(new LookupResult(lookupData.getWebServiceUrl(),
-                                    lookupData.getWebServiceUrlTls(), listener.getBrokerServiceUrl().toString(),
+                                    lookupData.getWebServiceUrlTls(), url == null ? null : url.toString(),
                                     urlTls == null ? null : urlTls.toString(), authoritativeRedirect));
                         }
                     } else {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -119,6 +119,7 @@ import org.apache.pulsar.broker.stats.ClusterReplicationMetrics;
 import org.apache.pulsar.broker.stats.prometheus.metrics.ObserverGauge;
 import org.apache.pulsar.broker.stats.prometheus.metrics.Summary;
 import org.apache.pulsar.broker.systopic.SystemTopicClient;
+import org.apache.pulsar.broker.validator.BindAddressValidator;
 import org.apache.pulsar.broker.web.PulsarWebResource;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.admin.PulsarAdminBuilder;
@@ -128,6 +129,7 @@ import org.apache.pulsar.client.impl.ClientBuilderImpl;
 import org.apache.pulsar.client.impl.PulsarClientImpl;
 import org.apache.pulsar.client.impl.conf.ClientConfigurationData;
 import org.apache.pulsar.common.allocator.PulsarByteBufAllocator;
+import org.apache.pulsar.common.configuration.BindAddress;
 import org.apache.pulsar.common.configuration.FieldContext;
 import org.apache.pulsar.common.intercept.AppendIndexMetadataInterceptor;
 import org.apache.pulsar.common.intercept.BrokerEntryMetadataInterceptor;
@@ -259,6 +261,7 @@ public class BrokerService implements Closeable, ZooKeeperCacheListener<Policies
     private final DelayedDeliveryTrackerFactory delayedDeliveryTrackerFactory;
     private final ServerBootstrap defaultServerBootstrap;
 
+    private final List<Channel> listenChannels = new ArrayList<>(2);
     private Channel listenChannel;
     private Channel listenChannelTls;
 
@@ -413,37 +416,35 @@ public class BrokerService implements Closeable, ZooKeeperCacheListener<Policies
         this.producerNameGenerator = new DistributedIdGenerator(pulsar.getCoordinationService(),
                 PRODUCER_NAME_GENERATOR_PATH, pulsar.getConfiguration().getClusterName());
 
-        ServerBootstrap bootstrap = defaultServerBootstrap.clone();
-
         ServiceConfiguration serviceConfig = pulsar.getConfiguration();
+        List<BindAddress> bindAddresses = BindAddressValidator.validateBindAddresses(serviceConfig);
+        String internalListenerName = serviceConfig.getInternalListenerName();
 
-        bootstrap.childHandler(new PulsarChannelInitializer(pulsar, false));
-
-        Optional<Integer> port = serviceConfig.getBrokerServicePort();
-        if (port.isPresent()) {
-            // Bind and start to accept incoming connections.
-            InetSocketAddress addr = new InetSocketAddress(pulsar.getBindAddress(), port.get());
+        // create a server socket for each bind address
+        for (BindAddress a : bindAddresses) {
+            InetSocketAddress addr = new InetSocketAddress(a.getAddress().getHost(), a.getAddress().getPort());
+            String listenerName = a.getListenerName();
+            ServerBootstrap b = defaultServerBootstrap.clone();
+            b.childHandler(new PulsarChannelInitializer(pulsar, a.isTLS(), a.getListenerName()));
             try {
-                listenChannel = bootstrap.bind(addr).sync().channel();
-                log.info("Started Pulsar Broker service on {}", listenChannel.localAddress());
+                Channel ch = b.bind(addr).sync().channel();
+                listenChannels.add(ch);
+
+                if (listenerName == null || StringUtils.equalsIgnoreCase(listenerName, internalListenerName)) {
+                    // use the internal listener as the primary channel.
+                    if (this.listenChannel == null && !a.isTLS()) {
+                        this.listenChannel = ch;
+                    }
+                    if (this.listenChannelTls == null && a.isTLS()) {
+                        this.listenChannelTls = ch;
+                    }
+                }
+
+                log.info("Started Pulsar Broker service on {}, TLS: {}",
+                        ch.localAddress(),
+                        a.isTLS() ? SslContext.defaultServerProvider().toString() : "(none)");
             } catch (Exception e) {
                 throw new IOException("Failed to bind Pulsar broker on " + addr, e);
-            }
-        }
-
-        Optional<Integer> tlsPort = serviceConfig.getBrokerServicePortTls();
-        if (tlsPort.isPresent()) {
-            ServerBootstrap tlsBootstrap = bootstrap.clone();
-            tlsBootstrap.childHandler(new PulsarChannelInitializer(pulsar, true));
-            try {
-                listenChannelTls = tlsBootstrap.bind(new InetSocketAddress(
-                        pulsar.getBindAddress(), tlsPort.get())).sync()
-                        .channel();
-                log.info("Started Pulsar Broker TLS service on {} - TLS provider: {}", listenChannelTls.localAddress(),
-                        SslContext.defaultServerProvider());
-            } catch (Exception e) {
-                throw new IOException(String.format("Failed to start Pulsar Broker TLS service on %s:%d",
-                        pulsar.getBindAddress(), tlsPort.get()), e);
             }
         }
 
@@ -711,14 +712,11 @@ public class BrokerService implements Closeable, ZooKeeperCacheListener<Policies
                                 log.info("Continuing to second phase in shutdown.");
 
                                 List<CompletableFuture<Void>> asyncCloseFutures = new ArrayList<>();
-
-                                if (listenChannel != null && listenChannel.isOpen()) {
-                                    asyncCloseFutures.add(closeChannel(listenChannel));
-                                }
-
-                                if (listenChannelTls != null && listenChannelTls.isOpen()) {
-                                    asyncCloseFutures.add(closeChannel(listenChannelTls));
-                                }
+                                listenChannels.forEach(ch -> {
+                                    if (ch.isOpen()) {
+                                        asyncCloseFutures.add(closeChannel(ch));
+                                    }
+                                });
 
                                 if (interceptor != null) {
                                     interceptor.close();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/PulsarChannelInitializer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/PulsarChannelInitializer.java
@@ -46,6 +46,7 @@ public class PulsarChannelInitializer extends ChannelInitializer<SocketChannel> 
 
     private final PulsarService pulsar;
     private final boolean enableTls;
+    private final String listenerName;
     private final boolean tlsEnabledWithKeyStore;
     private SslContextAutoRefreshBuilder<SslContext> sslCtxRefresher;
     private final ServiceConfiguration brokerConf;
@@ -64,11 +65,14 @@ public class PulsarChannelInitializer extends ChannelInitializer<SocketChannel> 
      *              An instance of {@link PulsarService}
      * @param enableTLS
      *              Enable tls or not
+     * @param listenerName
+     *              The listener associated with the channel, or null if the bind address has none.
      */
-    public PulsarChannelInitializer(PulsarService pulsar, boolean enableTLS) throws Exception {
+    public PulsarChannelInitializer(PulsarService pulsar, boolean enableTLS, String listenerName) throws Exception {
         super();
         this.pulsar = pulsar;
         this.enableTls = enableTLS;
+        this.listenerName = listenerName;
         ServiceConfiguration serviceConfig = pulsar.getConfiguration();
         this.tlsEnabledWithKeyStore = serviceConfig.isTlsEnabledWithKeyStore();
         if (this.enableTls) {
@@ -129,7 +133,7 @@ public class PulsarChannelInitializer extends ChannelInitializer<SocketChannel> 
         // ServerCnx ends up reading higher number of messages and broker can not throttle the messages by disabling
         // auto-read.
         ch.pipeline().addLast("flowController", new FlowControlHandler());
-        ServerCnx cnx = new ServerCnx(pulsar);
+        ServerCnx cnx = new ServerCnx(pulsar, this.listenerName);
         ch.pipeline().addLast("handler", cnx);
 
         connections.put(ch.remoteAddress(), cnx);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -151,6 +151,7 @@ import org.slf4j.LoggerFactory;
 public class ServerCnx extends PulsarHandler implements TransportCnx {
     private final BrokerService service;
     private final SchemaRegistryService schemaService;
+    private final String listenerName;
     private final ConcurrentLongHashMap<CompletableFuture<Producer>> producers;
     private final ConcurrentLongHashMap<CompletableFuture<Consumer>> consumers;
     private State state;
@@ -220,9 +221,14 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
     }
 
     public ServerCnx(PulsarService pulsar) {
+        this(pulsar, null);
+    }
+
+    public ServerCnx(PulsarService pulsar, String listenerName) {
         super(pulsar.getBrokerService().getKeepAliveIntervalSeconds(), TimeUnit.SECONDS);
         this.service = pulsar.getBrokerService();
         this.schemaService = pulsar.getSchemaRegistryService();
+        this.listenerName = listenerName;
         this.state = State.Start;
         ServiceConfiguration conf = pulsar.getConfiguration();
 
@@ -401,8 +407,10 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
     protected void handleLookup(CommandLookupTopic lookup) {
         final long requestId = lookup.getRequestId();
         final boolean authoritative = lookup.isAuthoritative();
+
+        // use the connection-specific listener name by default.
         final String advertisedListenerName = lookup.hasAdvertisedListenerName() ? lookup.getAdvertisedListenerName()
-                : null;
+                : this.listenerName;
         if (log.isDebugEnabled()) {
             log.debug("[{}] Received Lookup from {} for {}", lookup.getTopic(), remoteAddress, requestId);
         }

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/Commands.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/Commands.java
@@ -794,11 +794,13 @@ public class Commands {
         boolean authoritative, LookupType lookupType, long requestId, boolean proxyThroughServiceUrl) {
         BaseCommand cmd = localCmd(Type.LOOKUP_RESPONSE);
         CommandLookupTopicResponse response = cmd.setLookupTopicResponse()
-                .setBrokerServiceUrl(brokerServiceUrl)
                 .setResponse(lookupType)
                 .setRequestId(requestId)
                 .setAuthoritative(authoritative)
                 .setProxyThroughServiceUrl(proxyThroughServiceUrl);
+        if (brokerServiceUrl != null) {
+            response.setBrokerServiceUrl(brokerServiceUrl);
+        }
         if (brokerServiceUrlTls != null) {
             response.setBrokerServiceUrlTls(brokerServiceUrlTls);
         }

--- a/pulsar-common/src/main/java/org/apache/pulsar/policies/data/loadbalancer/AdvertisedListener.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/policies/data/loadbalancer/AdvertisedListener.java
@@ -24,6 +24,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import lombok.ToString;
 
 /**
  * The advertisedListener for broker with brokerServiceUrl and brokerServiceUrlTls.
@@ -31,6 +32,7 @@ import lombok.Setter;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@ToString
 public class AdvertisedListener {
     //
     @Getter
@@ -42,5 +44,4 @@ public class AdvertisedListener {
     @Setter
     // the broker service uri with ssl
     private URI brokerServiceUrlTls;
-
 }


### PR DESCRIPTION
Fixes https://github.com/streamnative/platform-epics/issues/310

Master Issue: #<xyz>

### Motivation


*Explain here the context, and why you're making that change. What is the problem you're trying to solve.*

### Modifications

*Describe the modifications you've done.*


Add a new configuration setting `bindAddresses` which resembles:
```
brokerServicePort=6650 
bindAddresses=external:pulsar://0.0.0.0:6652,external:pulsar+ssl://0.0.0.0:6653
```
The above would produce three server sockets, with `6650` having no associated listener name (thus retaining existing lookup behavior of returning the internal listener), and with `6652` and `6653` having an association with listener name `external`.  Given a lookup request on `6652` or `6653`, the `external` listener address would be returned.

The second change is to relax the validation logic of advertised listeners, to decouple from bind addresses.  For example, to have a TLS-terminated Istio gateway as the advertised listener (`external`), forwarding to a plaintext server socket (e.g. `6652` above).  Note that the advertised and bind ports need not be the same.
```
advertisedListeners=external:pulsar+ssl://broker-1.snio.cloud:6652,cluster:pulsar://broker-1.svc.local:6650
internalListenerName=cluster
```

The third change is to accept a header-based listener name in addition to the querystring-based name for lookup requests ([code reference](https://github.com/streamnative/pulsar/pull/3026/files#diff-1e0e8195fb5ec5a6d79acbc7d859c025a9b711f94e6ab37c94439e99b3202e84L401-L408)).  For example, for Istio gateway to provide a listener name hint (it is able to inject headers but not query string parameters).

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)
  - The rest endpoints: (yes / no)
  - The admin cli options: (yes / no)
  - Anything that affects deployment: (yes / no / don't know)

### Documentation

Check the box below and label this PR (if you have committer privilege).

Need to update docs? 

- [ ] doc-required 
  
  (If you need help on updating docs, create a doc issue)
  
- [ ] no-need-doc 
  
  (Please explain why)
  
- [ ] doc 
  
  (If this PR contains doc changes)


