### PR TITLE
update systemd service exit code

### DIFF
--- a/deployment/terraform-ansible/templates/pulsar.broker.service
+++ b/deployment/terraform-ansible/templates/pulsar.broker.service
@@ -27,6 +27,7 @@ WorkingDirectory=/opt/pulsar
 RestartSec=1s
 Restart=on-failure
 Type=simple
+SuccessExitStatus=143
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION

### Motivation
When admin runs "service stop broker", the status shows failed due to the broker process returns SIGTERM 15. 

### Modifications
Add the 143 code as exit success when stop the service

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.


### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API: (no)
  - The schema: ( no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no )

### Documentation

Check the box below or label this PR directly.

Need to update docs? 

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)
  
- [ x ] `no-need-doc` 
os systemd service stop behavior correction.  decoration issue
  
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-added`
(Docs have been already added)