### PR TITLE
ISSUE-18932: [Client] Drop jcommander dependency in Pulsar java client

### DIFF
--- a/pulsar-common/pom.xml
+++ b/pulsar-common/pom.xml
@@ -219,6 +219,7 @@
     <dependency>
       <groupId>com.beust</groupId>
       <artifactId>jcommander</artifactId>
+      <optional>true</optional>
     </dependency>
 
     <dependency>


### PR DESCRIPTION

Fixes ISSUE-18932: [Client] Drop jcommander dependency in Pulsar java client

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ Y] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment


